### PR TITLE
Kisoders/migrate from conda to venv

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,14 +12,16 @@ This project demonstrates a Semantic Kernel implementation with FastAPI backend,
 
 ### 1. Environment Setup
 
-Create a conda environment and install dependencies:
+Create a Python venv at the root of the project and install dependencies:
 
 ```bash
-# Create conda environment
-conda create -n sk python=3.10 -y
+# Create venv at project root
+python -m venv .venv
 
-# Activate environment
-conda activate sk
+# Activate venv (Windows)
+.venv\Scripts\activate
+# Activate venv (Unix/Linux/Mac)
+source .venv/bin/activate
 
 # Install requirements
 pip install -r requirements.txt
@@ -56,28 +58,14 @@ Navigate to the `src` directory and use the Python launcher:
 
 ```bash
 cd src
-
-# Use default conda environment (sk)
 python launcher.py
-
-# Use custom conda environment
-python launcher.py --env your_env_name
-
-# Or set environment variable
-set CONDA_ENV=your_env_name && python launcher.py  # Windows
-export CONDA_ENV=your_env_name && python launcher.py  # Unix/Linux
 ```
 
 #### Option B: Enhanced Batch Script (Windows)
 
 ```bash
 cd src
-
-# Use default environment
 run_chainlit.cmd
-
-# Use custom environment
-set CONDA_ENV=your_env_name && run_chainlit.cmd
 ```
 
 #### Option C: Manual Start (Individual Components)

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -12,73 +12,107 @@ import threading
 from pathlib import Path
 
 class ServiceManager:
-    def __init__(self, conda_env=None):
-        self.conda_env = conda_env or os.environ.get('CONDA_ENV', 'sk')
+    def __init__(self):
         self.processes = []
         self.base_dir = Path(__file__).parent
         
-    def get_conda_python(self):
-        """Get the python executable from the conda environment."""
+    def get_venv_python(self):
+        """Get the python executable from the .venv environment."""
+        venv_path = self.base_dir.parent / ".venv"
         if os.name == 'nt':  # Windows
-            return f"conda run -n {self.conda_env} python"
-        else:  # Unix-like
-            return f"conda run -n {self.conda_env} python"
-    
+            return str(venv_path / "Scripts" / "python.exe")
+        else:
+            return str(venv_path / "bin" / "python")
+
     def start_service(self, name, script_path, delay=0):
         """Start a service with optional delay."""
         if delay > 0:
             time.sleep(delay)
-        
         full_path = self.base_dir / script_path
-        cmd = f"{self.get_conda_python()} {full_path}"
-        
+        cmd = f'"{self.get_venv_python()}" "{full_path}"'
         print(f"Starting {name}...")
         try:
             if os.name == 'nt':  # Windows
                 process = subprocess.Popen(
-                    cmd, 
-                    shell=True, 
+                    cmd,
+                    shell=True,
                     creationflags=subprocess.CREATE_NEW_CONSOLE
                 )
             else:  # Unix-like
                 process = subprocess.Popen(cmd, shell=True)
-            
             self.processes.append((name, process))
             print(f"✓ {name} started (PID: {process.pid})")
-            
         except Exception as e:
             print(f"✗ Failed to start {name}: {e}")
-    
+
     def start_chainlit(self, app_path, delay=0):
         """Start the Chainlit application."""
         if delay > 0:
             time.sleep(delay)
-        
         full_path = self.base_dir / app_path
-        cmd = f"conda run -n {self.conda_env} chainlit run {full_path}"
-        
+        cmd = f'"{self.get_venv_python()}" -m chainlit run "{full_path}"'
         print(f"Starting Chainlit App...")
         try:
             if os.name == 'nt':  # Windows
                 process = subprocess.Popen(
-                    cmd, 
-                    shell=True, 
+                    cmd,
+                    shell=True,
                     creationflags=subprocess.CREATE_NEW_CONSOLE
                 )
             else:  # Unix-like
                 process = subprocess.Popen(cmd, shell=True)
-            
             self.processes.append(("Chainlit App", process))
             print(f"✓ Chainlit App started (PID: {process.pid})")
-            
         except Exception as e:
             print(f"✗ Failed to start Chainlit App: {e}")
-    
+
+    def check_ports(self, ports):
+        """Check and optionally kill processes using the specified ports."""
+        import psutil
+        import socket
+        active_ports = {}
+        for port in ports:
+            pids = set()
+            for conn in psutil.net_connections():
+                if conn.laddr and conn.laddr.port == port and conn.status == psutil.CONN_LISTEN:
+                    if conn.pid:
+                        pids.add(conn.pid)
+            if pids:
+                active_ports[port] = pids
+        if active_ports:
+            print("\nThe following ports are in use:")
+            for port, pids in active_ports.items():
+                print(f"  Port {port}: PIDs {', '.join(map(str, pids))}")
+            resp = input("\nDo you want to kill these processes? (y/n): ").strip().lower()
+            if resp == 'y':
+                for port, pids in active_ports.items():
+                    for pid in pids:
+                        try:
+                            p = psutil.Process(pid)
+                            p.terminate()
+                            print(f"✓ Killed PID {pid} on port {port}")
+                        except Exception as e:
+                            print(f"✗ Could not kill PID {pid} on port {port}: {e}")
+            else:
+                print("Skipping killing processes.")
+        else:
+            print("No active processes found on the specified ports.")
+
     def start_all_services(self):
         """Start all services in the correct order."""
-        print(f"Using conda environment: {self.conda_env}")
+        print(f"Using .venv environment at: {self.base_dir.parent / '.venv'}")
         print("=" * 50)
-        
+        # Port logic
+        ports = [8089, 8087, 8091, 8086, 8000, 8501]
+        try:
+            import psutil
+        except ImportError:
+            print("psutil not found. Installing...")
+            subprocess.check_call([self.get_venv_python(), "-m", "pip", "install", "psutil"])
+            import psutil
+        resp = input(f"Do you want to check which processes are using ports {ports}? (y/n): ").strip().lower()
+        if resp == 'y':
+            self.check_ports(ports)
         # Start MCP servers first
         services = [
             ("Weather MCP Server", "mcpservers/weather.py"),
@@ -86,25 +120,20 @@ class ServiceManager:
             ("Azure Data Explorer MCP Server", "mcpservers/azuredataexproler.py"),
             ("Backend Server", "backend/server.py"),
         ]
-        
         # Start services in parallel using threads
         threads = []
         for name, script_path in services:
             thread = threading.Thread(target=self.start_service, args=(name, script_path))
             thread.start()
             threads.append(thread)
-        
         # Wait for all services to start
         for thread in threads:
             thread.join()
-        
         # Give services time to initialize
         print("\nWaiting for services to initialize...")
         time.sleep(3)
-        
         # Start Chainlit app last
         self.start_chainlit("frontend/app.py")
-        
         print("\n" + "=" * 50)
         print("All services started!")
         print("Check the individual console windows for service status.")
@@ -128,26 +157,14 @@ class ServiceManager:
 
 def main():
     """Main entry point."""
-    import argparse
-    
-    parser = argparse.ArgumentParser(description='Launch Chainlit app with MCP servers')
-    parser.add_argument('--env', '-e', default='sk', 
-                       help='Conda environment name (default: sk or CONDA_ENV env var)')
-    
-    args = parser.parse_args()
-    
-    manager = ServiceManager(conda_env=args.env)
-    
+    manager = ServiceManager()
     # Set up signal handler for graceful shutdown
     signal.signal(signal.SIGINT, manager.signal_handler)
-    
     try:
         manager.start_all_services()
-        
         # Keep the main process alive
         while True:
             time.sleep(1)
-            
     except KeyboardInterrupt:
         manager.cleanup()
     except Exception as e:

--- a/src/run_chainlit.cmd
+++ b/src/run_chainlit.cmd
@@ -1,29 +1,58 @@
 @echo off
-REM Set default conda environment name (can be overridden)
-if "%CONDA_ENV%"=="" set CONDA_ENV=sk
+REM Set venv path (relative to this script)
+set VENV_PATH=..\.venv
 
-echo Starting services with conda environment: %CONDA_ENV%
+REM List of ports to check
+set PORTS=8089 8087 8091 8086 8000 8501
+
+REM Prompt user to check for active processes
+set /p CHECKPORTS="Do you want to check which processes are using ports %PORTS%? (y/n): "
+if /i "%CHECKPORTS%"=="y" (
+    for %%P in (%PORTS%) do (
+        echo Checking port %%P...
+        for /f "tokens=5" %%a in ('netstat -ano ^| findstr :%%P') do (
+            echo Port %%P is used by PID: %%a
+        )
+    )
+    pause
+    set /p KILLPORTS="Do you want to kill these processes? (y/n): "
+    if /i "%KILLPORTS%"=="y" (
+        for %%P in (%PORTS%) do (
+            for /f "tokens=5" %%a in ('netstat -ano ^| findstr :%%P') do (
+                echo Killing process on port %%P with PID %%a
+                taskkill /PID %%a /F >nul 2>&1
+            )
+        )
+        echo Ports checked and processes killed if found.
+    ) else (
+        echo Skipping killing processes.
+    )
+) else (
+    echo Skipping port check.
+)
+
+echo Starting services with venv: %VENV_PATH%
 echo.
 
 REM Start MCP servers
 echo Starting Weather MCP Server...
-start "Weather MCP" cmd /k "conda activate %CONDA_ENV% && python ./mcpservers/weather.py"
+start "Weather MCP" cmd /k "call %VENV_PATH%\Scripts\activate && python ./mcpservers/weather.py"
 
 echo Starting LocalTime MCP Server...
-start "LocalTime MCP" cmd /k "conda activate %CONDA_ENV% && python ./mcpservers/localtime.py"
+start "LocalTime MCP" cmd /k "call %VENV_PATH%\Scripts\activate && python ./mcpservers/localtime.py"
 
 echo Starting Azure Data Explorer MCP Server...
-start "Azure Data Explorer MCP" cmd /k "conda activate %CONDA_ENV% && python ./mcpservers/azuredataexproler.py"
+start "Azure Data Explorer MCP" cmd /k "call %VENV_PATH%\Scripts\activate && python ./mcpservers/azuredataexproler.py"
 
 REM Start backend server
 echo Starting Backend Server...
-start "Backend Server" cmd /k "conda activate %CONDA_ENV% && python ./backend/server.py"
+start "Backend Server" cmd /k "call %VENV_PATH%\Scripts\activate && python ./backend/server.py"
 
 REM Wait a moment for servers to start
 timeout /t 3 /nobreak >nul
 
 REM Start Chainlit frontend
 echo Starting Chainlit Frontend...
-start "Chainlit App" cmd /k "conda activate %CONDA_ENV% && chainlit run ./frontend/app.py"
+start "Chainlit App" cmd /k "call %VENV_PATH%\Scripts\activate && chainlit run ./frontend/app.py"
 
-echo All services started. Check individual terminal windows for status. 
+echo All services started. Check individual terminal windows for status.


### PR DESCRIPTION
This pull request transitions the project from using Conda environments to Python virtual environments (`venv`) for dependency management and execution. It includes updates to the documentation, scripts, and codebase to reflect this change, as well as enhancements for managing processes and ports. 

### Migration from Conda to venv:
- **Documentation Updates**:
  - Updated the `readme.md` to replace Conda setup instructions with `venv` setup instructions, including commands for creating and activating the virtual environment. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L15-R24) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L59-L80)

- **Code Changes**:
  - Modified `src/launcher.py` to remove Conda-specific logic and replace it with `venv`-specific logic for locating the Python executable and running scripts. [[1]](diffhunk://#diff-8e0b681a447a1be88d4e68226844b65e2c04d97431cdef40bbeebb8bb379ff2aL15-R32) [[2]](diffhunk://#diff-8e0b681a447a1be88d4e68226844b65e2c04d97431cdef40bbeebb8bb379ff2aL45-R53) [[3]](diffhunk://#diff-8e0b681a447a1be88d4e68226844b65e2c04d97431cdef40bbeebb8bb379ff2aL70-L107) [[4]](diffhunk://#diff-8e0b681a447a1be88d4e68226844b65e2c04d97431cdef40bbeebb8bb379ff2aL131-L150)

- **Script Updates**:
  - Updated `src/run_chainlit.cmd` to use `venv` activation commands instead of Conda activation commands.

### Process and Port Management Enhancements:
- **Port Checking and Killing**:
  - Added functionality in `src/launcher.py` to check for active processes on specified ports and optionally terminate them. This ensures that required ports are free before starting services.

- **Batch Script Enhancements**:
  - Enhanced `src/run_chainlit.cmd` to include prompts for checking and killing processes on specific ports prior to starting services.